### PR TITLE
Turn on event reception

### DIFF
--- a/client/client.ml
+++ b/client/client.ml
@@ -152,6 +152,7 @@ let _ =
 
   let thread = 
     let evtchn_h = Eventchn.init () in
+    let _ = Activations.run evtchn_h in
     lwt vch = V.client ~evtchn_h ~domid ~xs_path:(Printf.sprintf "/local/domain/%d/data/vchan" domid) in
     RpcM.vch := Some vch;
     fn ()


### PR DESCRIPTION
The 'wings fall off' switch defaults to 'true'; one must set it
to 'false' before take-off. This may not be the best design ever.

Signed-off-by: David Scott dave.scott@eu.citrix.com

(My CLI is now able to send multiple commands to my Mirage vchan instance)
