### PR TITLE
block-read-sector: now returns data

### DIFF
--- a/client/client.ml
+++ b/client/client.ml
@@ -37,7 +37,7 @@ let block_write_sector vbdid offset filename =
 
 let block_read_sector vbdid offset filename =
   lwt sector = Client.Vbd.read_sector vbdid offset in
-  lwt fd = Lwt_unix.openfile filename [Unix.O_RDWR] 0o644 in
+  lwt fd = Lwt_unix.openfile filename [Unix.O_CREAT; Unix.O_TRUNC; Unix.O_RDWR] 0o644 in
   let channel = Lwt_io.of_fd ~mode:Lwt_io.output fd in
   let sector = Cohttp.Base64.decode sector in
   lwt () = Lwt_io.write channel sector in

--- a/lib/vchan_http.ml
+++ b/lib/vchan_http.ml
@@ -34,18 +34,20 @@ struct
       else inner (s ^ buf) 
     in inner ""
 
-  let read ic n =
+  let read_exactly ic n =
     let buf = String.create n in
     let rec inner left =
-      if left = 0 then return buf else begin
+      if left = 0 then return (Some buf) else begin
 	V.read_into ic buf (n-left) left >>= fun x ->
-	inner (left - x)
+        if x = 0
+        then return None
+        else inner (left - x)
       end
     in inner n
 
-  let read_exactly ic len =
+  let read ic len =
     let s = String.create len in
-    V.read_into ic s 0 len >>= fun _ -> return (Some s)
+    V.read_into ic s 0 len >>= fun n -> return (String.sub s 0 n)
 
   let write oc s =
     lwt _ = V.write_from oc s 0 (String.length s) in Lwt.return ()


### PR DESCRIPTION
(although it returns 4096 bytes instead of the expected 512)

Signed-off-by: David Scott dave.scott@eu.citrix.com
