### PR TITLE
Use standard Mirage indent style

### DIFF
--- a/server/main.ml
+++ b/server/main.ml
@@ -29,7 +29,7 @@ let t1 () =
   console1 () >>= function
   | `Error e -> fail (Failure "console1")
   | `Ok console1 ->
-  M1.start console1
+    M1.start console1
 
 let () =
   OS.Main.run (join [t1 ()])

--- a/server/test.ml
+++ b/server/test.ml
@@ -46,7 +46,7 @@ let connect_blkifs xs =
 let rec serve_forever ctx vch =
   lwt () = Vchan_http.http_handler Jsonrpc.call_of_string Jsonrpc.string_of_response RpcServer.process vch ctx in
   serve_forever ctx vch
- 
+
 let with_vchan evtchn_h domid nodepath f =
   Printf.printf "Initializing Server domid=%d xs_path=%s\n%!" domid nodepath;
   V.server ~evtchn_h ~domid ~xs_path:nodepath
@@ -55,7 +55,7 @@ let with_vchan evtchn_h domid nodepath f =
   let flow = Vchan_http.openflow vch in
   Printf.printf "Initialization done!\n%!";
   f flow
-      
+
 
 open V1_LWT
 
@@ -70,8 +70,8 @@ module Main (C:CONSOLE) = struct
     echo vch
 
   let start c =
-(*    Mirage_guest_agent.control_watch ();
-    Mirage_guest_agent.dummy_guest_agent ();*)
+    (*    Mirage_guest_agent.control_watch ();
+          Mirage_guest_agent.dummy_guest_agent ();*)
     lwt xs = Xs.make () in
     (*lwt blkifs = connect_blkifs xs in*)
     ignore(with_vchan (Eventchn.init ()) 0 "data/vchan" (serve_forever [](*blkifs*)));

--- a/server/test_impl.ml
+++ b/server/test_impl.ml
@@ -32,7 +32,7 @@ let shutdown context () =
     Lwt.return ()
   in
   Lwt.return ()
-    
+
 let reboot context () =
   let thread = 
     lwt () = Time.sleep 0.1 in
@@ -40,7 +40,7 @@ let reboot context () =
     Lwt.return () 
   in
   Lwt.return ()
-    
+
 let crash context () =
   let thread = 
     lwt () = Time.sleep 0.1 in
@@ -83,14 +83,14 @@ module Vbd = struct
     Lwt.return devids
 
   let start_hammer context devid = 
-(*    let _ = Block.block_hammer () in*)
+    (*    let _ = Block.block_hammer () in*)
     Lwt.return ()
 
   let stop_hammer context devid = 
     Lwt.return ()
 
   let start_tickle context devid =
-(*    let _ = Block.block_tickle () in*)
+    (*    let _ = Block.block_tickle () in*)
     Lwt.return ()
 
   let stop_tickle context devid =
@@ -106,21 +106,21 @@ end
 
 module Vif = struct
   let list context () =
-(*    match !net_manager with 
-    | Some t ->
-      let vifs = Net.Manager.get_intfs t in
-      Lwt.return (List.map (fun (x,y) -> OS.Netif.string_of_id x) vifs)
-    | None -> *)
-      Lwt.return []
+    (*    match !net_manager with 
+          | Some t ->
+          let vifs = Net.Manager.get_intfs t in
+          Lwt.return (List.map (fun (x,y) -> OS.Netif.string_of_id x) vifs)
+          | None -> *)
+    Lwt.return []
 
   let get_ipv4 context vifid =
-(*    match !net_manager with 
-    | Some t ->
-      let id = OS.Netif.id_of_string vifid in
-      let addr = Net.Manager.get_intf_ipv4addr t id in
-      Lwt.return (Ipaddr.V4.to_string addr)
-    | None ->*)
-      Lwt.return ""
+    (*    match !net_manager with 
+          | Some t ->
+          let id = OS.Netif.id_of_string vifid in
+          let addr = Net.Manager.get_intf_ipv4addr t id in
+          Lwt.return (Ipaddr.V4.to_string addr)
+          | None ->*)
+    Lwt.return ""
 
   let inject_packet context vifid packet = 
     Lwt.return ()


### PR DESCRIPTION
  ocp-indent --syntax=lwt -i *.ml

Signed-off-by: David Scott dave.scott@citrix.com
